### PR TITLE
Update to work with grails 2.4.2

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.0.4
+app.grails.version=2.4.2

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,7 @@ grails.project.dependency.resolution = {
 
 	plugins {
 		compile ':google-visualization:0.6'
-		compile ':jquery:1.8.2'
+		compile ':jquery:1.11.0.2'
 
 		build(':release:2.0.4', ':rest-client-builder:1.0.2') {
 			export = false

--- a/grails-app/taglib/grails/plugin/p6spy/ui/P6SpyTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/p6spy/ui/P6SpyTagLib.groovy
@@ -1,6 +1,6 @@
 package grails.plugin.p6spy.ui
 
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
+import grails.util.Holders
 
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
@@ -10,7 +10,7 @@ class P6SpyTagLib {
 	static namespace = 'p6'
 
 	def resources = { attrs ->
-		boolean hasResourcesPlugin = PluginManagerHolder.pluginManager.hasGrailsPlugin('resources')
+		boolean hasResourcesPlugin = Holders.getPluginManager().hasGrailsPlugin('resources')
 
 		if (hasResourcesPlugin) {
 			r.require(module: 'p6spy-ui')
@@ -26,7 +26,7 @@ class P6SpyTagLib {
 	}
 
 	def layoutResources = { attrs ->
-		boolean hasResourcesPlugin = PluginManagerHolder.pluginManager.hasGrailsPlugin('resources')
+		boolean hasResourcesPlugin = Holders.getPluginManager().hasGrailsPlugin('resources')
 
 		if (hasResourcesPlugin) {
 			out << r.layoutResources()


### PR DESCRIPTION
Burt, these are the changes that I discussed with you at GR8Conf US. Unfortunately the build fails because of the test-app step, and there don't seem to be any tests, so I'm not sure if that is expected, or if I'm running the incorrect commands (i.e. "ant"), let me know if you'd like me to try something different. Thanks!

Related to issue #6 

Removed references to PluginManagerHolder (removed in Grails 2.4), and
replaced with Holders.getPluginManager()

Updated the jquery plugin from 1.8.2 to 1.11.0.2, as recommended here:
http://grails.org/doc/2.4.2/guide/upgradingFrom23.html